### PR TITLE
Add d3d12 to aarch64 build

### DIFF
--- a/mesa.spec
+++ b/mesa.spec
@@ -29,14 +29,14 @@
 %global with_vc4       1
 %global with_v3d       1
 %endif
-%global with_d3d12  1
-%global __meson_wrap_mode default
+%global with_d3d12     1
 %global with_freedreno 1
 %global with_kmsro     1
 %global with_panfrost  1
 %global with_tegra     1
 %global with_xa        1
 %global platform_vulkan ,broadcom,freedreno
+%global __meson_wrap_mode default
 %endif
 
 %ifnarch %{arm} s390x

--- a/mesa.spec
+++ b/mesa.spec
@@ -29,6 +29,8 @@
 %global with_vc4       1
 %global with_v3d       1
 %endif
+%global with_d3d12  1
+%global __meson_wrap_mode default
 %global with_freedreno 1
 %global with_kmsro     1
 %global with_panfrost  1


### PR DESCRIPTION
- Add D3D12 build to aarch64
- Still doesn't work yet due to [lack of drivers](https://github.com/microsoft/wslg/issues/260)